### PR TITLE
Add minification step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 resolvewithplus
 ===============
-[![npm version](https://badge.fury.io/js/resolvewithplus.svg)](https://badge.fury.io/js/resolvewithplus) [![Build Status](https://github.com/iambumblehead/resolvewithplus/workflows/nodejs-ci/badge.svg)][2]
+[![npm version](https://badge.fury.io/js/resolvewithplus.svg)](https://badge.fury.io/js/resolvewithplus) [![Build Status](https://github.com/iambumblehead/resolvewithplus/workflows/nodejs-ci/badge.svg)][2][[![install size](https://packagephobia.now.sh/badge?p=resolvewithplus)](https://packagephobia.now.sh/result?p=resolvewithplus)
 
 _resolvewithplus_ iterates on the _resolvewith_ package for resolving CJS modules following [the original node.js spec.][2] _resolvewithplus_ is changed to an ESM module and adds support for ESM `import 'name'` resolutions.
 
@@ -30,13 +30,3 @@ _resolvewithplus_ caches and reuse results it generates. The first call follows 
 [4]: https://github.com/substack/browserify-handbook#browser-field
 
  ![scrounge](https://github.com/iambumblehead/scroungejs/raw/master/img/hand.png) 
-
-(The MIT License)
-
-Copyright (c) [Bumblehead][0] <chris@bumblehead.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "test": "ava resolvewithplus.spec.mjs",
     "lint": "eslint ./*mjs",
-    "prepublish": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n; npm pkg delete devDependencies scripts"
+    "mini": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n",
+    "prepublishOnly": "npm run mini; npm pkg delete devDependencies scripts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "resolvewithplus",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "ISC",
   "main": "resolvewithplus.mjs",
   "readmeFilename": "README.md",
   "description": "resolvewith with extra power",
   "type": "module",
   "files": [
-    "resolvewithplus.mjs",
-    "README.md"
+    "resolvewithplus.mjs"
   ],
   "repository": {
     "type": "git",
@@ -34,6 +33,7 @@
   },
   "scripts": {
     "test": "ava resolvewithplus.spec.mjs",
-    "lint": "eslint ./*mjs"
+    "lint": "eslint ./*mjs",
+    "prepublish": "n=resolvewithplus.mjs && npx esbuild $n --minify > $n"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "scripts": {
     "test": "ava resolvewithplus.spec.mjs",
     "lint": "eslint ./*mjs",
-    "prepublish": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n"
+    "prepublish": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n; npm pkg delete devDepdendencies scripts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "scripts": {
     "test": "ava resolvewithplus.spec.mjs",
     "lint": "eslint ./*mjs",
-    "prepublish": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n; npm pkg delete devDepdendencies scripts"
+    "prepublish": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n; npm pkg delete devDependencies scripts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "scripts": {
     "test": "ava resolvewithplus.spec.mjs",
     "lint": "eslint ./*mjs",
-    "prepublish": "n=resolvewithplus.mjs && npx esbuild $n --minify > $n"
+    "prepublish": "n=resolvewithplus.mjs; o=$(npx esbuild $n --minify); echo $o > $n"
   }
 }

--- a/resolvewithplus.mjs
+++ b/resolvewithplus.mjs
@@ -9,6 +9,8 @@ const isDirPathRe = /^\.?\.?(\/|\\)/;
 const isRelPathRe = /^.\.?(?=\/|\\)/;
 const isSupportedIndexRe = /index.[tj]sx?$/;
 const supportedExtensions = [ '.js', '.mjs', '.ts', '.tsx', '.json', '.node' ];
+const node_modules = 'node_modules';
+const packagejson = 'package.json';
 
 export default (o => {
   o = (requirepath, withpath, opts) => {
@@ -144,7 +146,7 @@ export default (o => {
   o.getasdirsync = (d, opts) => {
     let filepath = null;
     let relpath;
-    let json = path.join(d, 'package.json');
+    let json = path.join(d, packagejson);
 
     if ((relpath = o.getpackagepath(json, opts))) {
       filepath = o.getasfilesync(path.join(d, relpath));
@@ -195,7 +197,7 @@ export default (o => {
     for (let x = parts.length; x--;) {
       if (parts[x]) {
         packagejsonpath =
-          join(sep, join.apply(x, parts.slice(0, x + 1)), 'package.json');
+          join(sep, join.apply(x, parts.slice(0, x + 1)), packagejson);
         if (o.isfilesync(packagejsonpath)) {
           packagejson = require(packagejsonpath);
           break;
@@ -220,7 +222,7 @@ export default (o => {
   // 5. return DIRS
   o.getasnode_module_paths = start => start.split(path.sep).slice(1)
     .reduce((prev, p, i) => {
-      if (p === 'node_modules')
+      if (p === node_modules)
         return prev;
 
       // windows and linux paths split differently
@@ -228,7 +230,7 @@ export default (o => {
       p = path.resolve(path.join(i ? prev[0][i-1] : path.sep, p));
     
       prev[0].push(p);
-      prev[1].push(path.join(p, 'node_modules'));
+      prev[1].push(path.join(p, node_modules));
 
       return prev;
     }, [ [], [] ])[1].reverse();


### PR DESCRIPTION
this adds prepublishing minification,
 * _resolvewithplus.mjs_ -5079, from 7282 to 2203
 * _package.json_ -381, from 885 to 504
 * _README.md_ -970, from 2911 to 1941
 * **_total,_ 6430** _(~6.4Kb)_


cc @Swivelgames the current "install size" [is shown here][0] as 11.4kB.  It will be interesting to see what size is shown after the update.


[0]: https://packagephobia.com/result?p=resolvewithplus