### PR TITLE
support first set of nodejs export patterns, add unit-tests

### DIFF
--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -3,6 +3,10 @@ import path from 'path';
 import module from 'module';
 
 const require = module.createRequire(import.meta.url);
+// https://nodejs.org/api/fs.html#fsrealpathpath-options-callback
+// realpath removes '..', '.' and converts symlinks to the true path,
+// which is also used by nodejs' internal resolver
+const realpath = fs.realpathSync.native;
 const isBuiltinRe = new RegExp(
   '^('+module.builtinModules.join('|').replace('/', '\/')+')$');
 const isDirPathRe = /^\.?\.?(\/|\\)/;
@@ -47,14 +51,13 @@ export default (o => {
       fullpath = requirepath;
     } else if (isDirPathRe.test(requirepath)) {
       fullpath = o.getasfileordir(requirepath, withpath, opts);
+      fullpath = fullpath && realpath(fullpath);
     } else {
       fullpath = o.getasnode_module(requirepath, withpath);
+      fullpath = fullpath && realpath(fullpath);
     }
 
-    // https://nodejs.org/api/fs.html#fsrealpathpath-options-callback
-    // realpath removes '..', '.' and converts symlinks to the true path,
-    // which is also used by nodejs' internal resolver
-    return fullpath && fs.realpathSync.native(fullpath);
+    return fullpath;
   };
 
   o.iscoremodule = p => isBuiltinRe.test(p);

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -95,10 +95,13 @@ export default (o => {
         // }
         indexval = esmexportsobj.import;
       } else if (esmexportsobj['.']) {
+        // "exports": {
+        //   ".": "./lib/index.js"
+        // }
         if (typeof esmexportsobj['.'] === 'string') {
           indexval = esmexportsobj['.'];
         }
-        
+
         if (typeof esmexportsobj['.'].import === 'string') {
           indexval = esmexportsobj['.'].import;
         }

--- a/tests/testfiles/testscript.js
+++ b/tests/testfiles/testscript.js
@@ -1,28 +1,8 @@
-import libindex1 from 'nodejsexample_01_exports';
-import libindex2 from 'nodejsexample_01_exports/lib';
-import libindex3 from 'nodejsexample_01_exports/lib/index';
-import libindex4 from 'nodejsexample_01_exports/lib/index.js';
+// Filename: testscript.js  
+// Timestamp: 2015.07.15-12:04:02 (last modified)
+// Author(s): bumblehead <chris@bumblehead.com>
 
-import featureindex1 from 'nodejsexample_01_exports/feature';
-import featureindex2 from 'nodejsexample_01_exports/feature/index';
-import featureindex3 from 'nodejsexample_01_exports/feature/index.js';
+const modulea = require('./path/to/indexfile');
+const moduleb = require('testmodule');
 
-const libindex1wrap = () => libindex1
-const libindex2wrap = () => libindex2
-const libindex3wrap = () => libindex3
-const libindex4wrap = () => libindex4
-
-const featureindex1wrap = () => featureindex1
-const featureindex2wrap = () => featureindex2
-const featureindex3wrap = () => featureindex3
-
-export {
-  libindex1wrap,
-  libindex2wrap,
-  libindex3wrap,
-  libindex4wrap,
-
-  featureindex1wrap,
-  featureindex2wrap,
-  featureindex3wrap
-};
+module.exports = { modulea, moduleb };

--- a/tests/testfiles/testscript.js
+++ b/tests/testfiles/testscript.js
@@ -1,8 +1,28 @@
-// Filename: testscript.js  
-// Timestamp: 2015.07.15-12:04:02 (last modified)
-// Author(s): bumblehead <chris@bumblehead.com>
+import libindex1 from 'nodejsexample_01_exports';
+import libindex2 from 'nodejsexample_01_exports/lib';
+import libindex3 from 'nodejsexample_01_exports/lib/index';
+import libindex4 from 'nodejsexample_01_exports/lib/index.js';
 
-const modulea = require('./path/to/indexfile');
-const moduleb = require('testmodule');
+import featureindex1 from 'nodejsexample_01_exports/feature';
+import featureindex2 from 'nodejsexample_01_exports/feature/index';
+import featureindex3 from 'nodejsexample_01_exports/feature/index.js';
 
-module.exports = { modulea, moduleb };
+const libindex1wrap = () => libindex1
+const libindex2wrap = () => libindex2
+const libindex3wrap = () => libindex3
+const libindex4wrap = () => libindex4
+
+const featureindex1wrap = () => featureindex1
+const featureindex2wrap = () => featureindex2
+const featureindex3wrap = () => featureindex3
+
+export {
+  libindex1wrap,
+  libindex2wrap,
+  libindex3wrap,
+  libindex4wrap,
+
+  featureindex1wrap,
+  featureindex2wrap,
+  featureindex3wrap
+};

--- a/tests/tests-basic/nodejsexample_01_exports/feature/index.js
+++ b/tests/tests-basic/nodejsexample_01_exports/feature/index.js
@@ -1,0 +1,1 @@
+export default 'feature-index';

--- a/tests/tests-basic/nodejsexample_01_exports/lib/index.js
+++ b/tests/tests-basic/nodejsexample_01_exports/lib/index.js
@@ -1,0 +1,1 @@
+export default 'lib-index';

--- a/tests/tests-basic/nodejsexample_01_exports/package.json
+++ b/tests/tests-basic/nodejsexample_01_exports/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nodejsexample_01_exports",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iambumblehead/resolvewithplus.git"
+  },
+  "exports": {
+    ".": "./lib/index.js",
+    "./lib": "./lib/index.js",
+    "./lib/index": "./lib/index.js",
+    "./lib/index.js": "./lib/index.js",
+    "./feature": "./feature/index.js",
+    "./feature/index": "./feature/index.js",
+    "./feature/index.js": "./feature/index.js",
+    "./package.json": "./package.json"
+  }
+}

--- a/tests/tests-basic/package.json
+++ b/tests/tests-basic/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/iambumblehead/resolvewithplus.git"
   },
   "dependencies": {
+    "nodejsexample_01_exports": "file:nodejsexample_01_exports",
     "resolvewithplus": "file:.."
   },
   "scripts": {

--- a/tests/tests-basic/tests-basic.test.js
+++ b/tests/tests-basic/tests-basic.test.js
@@ -225,4 +225,3 @@ test('should handle mixed exports', () => {
     }
   }), './index.mjs');
 });
-

--- a/tests/tests-basic/tests-basic.test.js
+++ b/tests/tests-basic/tests-basic.test.js
@@ -169,7 +169,7 @@ test('getasnode_module_paths, should return list of paths (posix)', () => {
 });
 
 test('should handle exports.import path definition', () => {
-  assert.strictEqual(resolvewithplus.getbrowserindex({
+  assert.strictEqual(resolvewithplus.gettargetindex({
     name : 'test',
     exports : {
       types : './index.d.ts',
@@ -181,7 +181,7 @@ test('should handle exports.import path definition', () => {
 
 test('should handle exports["."].import path definition', () => {
   // used by 'koa@2.13.4'
-  assert.strictEqual(resolvewithplus.getbrowserindex({
+  assert.strictEqual(resolvewithplus.gettargetindex({
     name : 'test',
     exports : {
       '.' : {
@@ -194,7 +194,7 @@ test('should handle exports["."].import path definition', () => {
 
 test('should handle exports stringy path definition', () => {
   // used by 'got'
-  assert.strictEqual(resolvewithplus.getbrowserindex({
+  assert.strictEqual(resolvewithplus.gettargetindex({
     name : 'test',
     exports : './index.mjs'
   }), './index.mjs');
@@ -202,7 +202,7 @@ test('should handle exports stringy path definition', () => {
 
 test('should handle mixed exports', () => {
   // used by 'yargs@17.5.1'
-  assert.strictEqual(resolvewithplus.getbrowserindex({
+  assert.strictEqual(resolvewithplus.gettargetindex({
     name : 'test',
     exports : {
       './package.json' : './package.json',

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -1,0 +1,39 @@
+import path from 'path';
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import resolvewithplus from 'resolvewithplus';
+
+test('should mock all exports from nodejsexample_01_exports', () => {
+  const noderesolvedlibindex = path
+    .resolve('./nodejsexample_01_exports/lib/index.js');
+  const noderesolvedfeatureindex = path
+    .resolve('./nodejsexample_01_exports/feature/index.js');
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/lib'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/lib/index'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/lib/index.js'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/feature'),
+    noderesolvedfeatureindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/feature/index'),
+    noderesolvedfeatureindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/feature/index.js'),
+    noderesolvedfeatureindex);
+});

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -3,6 +3,20 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import resolvewithplus from 'resolvewithplus';
 
+// from: https://nodejs.org/api/packages.html#package-entry-points
+// {
+//   "name": "my-package",
+//   "exports": {
+//     ".": "./lib/index.js",
+//     "./lib": "./lib/index.js",
+//     "./lib/index": "./lib/index.js",
+//     "./lib/index.js": "./lib/index.js",
+//     "./feature": "./feature/index.js",
+//     "./feature/index": "./feature/index.js",
+//     "./feature/index.js": "./feature/index.js",
+//     "./package.json": "./package.json"
+//   }
+// }
 test('should mock all exports from nodejsexample_01_exports', () => {
   const noderesolvedlibindex = path
     .resolve('./nodejsexample_01_exports/lib/index.js');

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -22,6 +22,8 @@ test('should mock all exports from nodejsexample_01_exports', () => {
     .resolve('./nodejsexample_01_exports/lib/index.js');
   const noderesolvedfeatureindex = path
     .resolve('./nodejsexample_01_exports/feature/index.js');
+  const noderesolvedpackagejson = path
+    .resolve('./nodejsexample_01_exports/package.json');
 
   assert.strictEqual(
     resolvewithplus('nodejsexample_01_exports'),
@@ -50,4 +52,8 @@ test('should mock all exports from nodejsexample_01_exports', () => {
   assert.strictEqual(
     resolvewithplus('nodejsexample_01_exports/feature/index.js'),
     noderesolvedfeatureindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_01_exports/package.json'),
+    noderesolvedpackagejson)
 });


### PR DESCRIPTION
@tripodsan @aladdin-add if either of you are available and would please review my changes that would be great.

This PR begins the process of testing example esm export patterns from nodejs' documentation site here https://nodejs.org/api/packages.html#package-entry-points
```json
{
  "name": "my-package",
  "exports": {
    ".": "./lib/index.js",
    "./lib": "./lib/index.js",
    "./lib/index": "./lib/index.js",
    "./lib/index.js": "./lib/index.js",
    "./feature": "./feature/index.js",
    "./feature/index": "./feature/index.js",
    "./feature/index.js": "./feature/index.js",
    "./package.json": "./package.json"
  }
}
```

I hope to continue making PRs until all or most of the patterns there are supported and unit-tested. I'll try to add support in small chunks so that the PRs will be readable.

Two bugs were found and resolved,
 1. fs.realPathSync is added to return the true system path with symlinks removed (the paths should not have symlinks and the symlinks caused the tests to fail) related https://github.com/iambumblehead/esmock/pull/69
 2. the resolver was updated to support this pattern `{ "exports": { ".": "./lib/index.js" } }`