### PR TITLE
add second set of tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
    * begin dusting off this old package
    * move tests into subdirectory, prepare for multiple test packages
    * use shields io npm badge
+   * add tests for export patterns from nodejs documentation
+   * add exports.import definition

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.8.6",
   "license": "ISC",
   "main": "resolvewithplus.js",
+  "exports": {
+    "import": "resolvewithplus.js"
+  },
   "readmeFilename": "README.md",
   "description": "resolvewith with extra power",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "resolvewithplus",
   "version": "0.8.6",
+  "engines" : { 
+    "node" : ">=12.16.0"
+  },
   "license": "ISC",
   "main": "resolvewithplus.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "main": "resolvewithplus.js",
   "exports": {
-    "import": "resolvewithplus.js"
+    "import": "./resolvewithplus.js"
   },
   "readmeFilename": "README.md",
   "description": "resolvewith with extra power",

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -49,11 +49,11 @@ export default (o => {
 
     if (isBuiltinRe.test(requirepath)) {
       fullpath = requirepath;
-    } else if (isDirPathRe.test(requirepath)) {
-      fullpath = o.getasfileordir(requirepath, withpath, opts);
-      fullpath = fullpath && realpath(fullpath);
     } else {
-      fullpath = o.getasnode_module(requirepath, withpath);
+      fullpath = isDirPathRe.test(requirepath)
+        ? o.getasfileordir(requirepath, withpath, opts)
+        : o.getasnode_module(requirepath, withpath);
+
       fullpath = fullpath && realpath(fullpath);
     }
 
@@ -104,7 +104,11 @@ export default (o => {
         if (typeof esmexportsobj['.'] === 'string') {
           indexval = esmexportsobj['.'];
         }
-
+        // "exports": {
+        //   ".": {
+        //     "import": "./lib/index.js"
+        //   }
+        // }
         if (typeof esmexportsobj['.'].import === 'string') {
           indexval = esmexportsobj['.'].import;
         }

--- a/tests/tests-basic/nodejsexample_02_exports/feature/index.js
+++ b/tests/tests-basic/nodejsexample_02_exports/feature/index.js
@@ -1,0 +1,1 @@
+export default 'feature-index';

--- a/tests/tests-basic/nodejsexample_02_exports/lib/index.js
+++ b/tests/tests-basic/nodejsexample_02_exports/lib/index.js
@@ -1,0 +1,1 @@
+export default 'lib-index';

--- a/tests/tests-basic/nodejsexample_02_exports/package.json
+++ b/tests/tests-basic/nodejsexample_02_exports/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nodejsexample_02_exports",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iambumblehead/resolvewithplus.git"
+  },
+  "exports": {
+    ".": "./lib/index.js",
+    "./lib": "./lib/index.js",
+    "./lib/*": "./lib/*.js",
+    "./lib/*.js": "./lib/*.js",
+    "./feature": "./feature/index.js",
+    "./feature/*": "./feature/*.js",
+    "./feature/*.js": "./feature/*.js",
+    "./package.json": "./package.json"
+  }
+}

--- a/tests/tests-basic/nodejsexample_03_exports/feature/index.js
+++ b/tests/tests-basic/nodejsexample_03_exports/feature/index.js
@@ -1,0 +1,1 @@
+export default 'feature-index';

--- a/tests/tests-basic/nodejsexample_03_exports/lib/index.js
+++ b/tests/tests-basic/nodejsexample_03_exports/lib/index.js
@@ -1,0 +1,1 @@
+export default 'lib-index';

--- a/tests/tests-basic/nodejsexample_03_exports/package.json
+++ b/tests/tests-basic/nodejsexample_03_exports/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nodejsexample_03_exports",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iambumblehead/resolvewithplus.git"
+  },
+  "exports": {
+    ".": "./lib/index.js",
+    "./feature/*.js": "./feature/*.js",
+    "./feature/internal/*": null
+  }
+}

--- a/tests/tests-basic/nodejsexample_04_exports/lib/index.js
+++ b/tests/tests-basic/nodejsexample_04_exports/lib/index.js
@@ -1,0 +1,1 @@
+export default 'lib-index';

--- a/tests/tests-basic/nodejsexample_04_exports/package.json
+++ b/tests/tests-basic/nodejsexample_04_exports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nodejsexample_04_exports",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iambumblehead/resolvewithplus.git"
+  },
+  "exports": "./lib/index.js"
+}

--- a/tests/tests-basic/package.json
+++ b/tests/tests-basic/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "nodejsexample_01_exports": "file:nodejsexample_01_exports",
+    "nodejsexample_02_exports": "file:nodejsexample_02_exports",
     "resolvewithplus": "file:.."
   },
   "scripts": {

--- a/tests/tests-basic/package.json
+++ b/tests/tests-basic/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "nodejsexample_01_exports": "file:nodejsexample_01_exports",
     "nodejsexample_02_exports": "file:nodejsexample_02_exports",
+    "nodejsexample_03_exports": "file:nodejsexample_03_exports",
+    "nodejsexample_04_exports": "file:nodejsexample_04_exports",
     "resolvewithplus": "file:.."
   },
   "scripts": {

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -3,7 +3,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import resolvewithplus from 'resolvewithplus';
 
-// from: https://nodejs.org/api/packages.html#package-entry-points
+// from: https://nodejs.org/api/packages.html#package-entry-pointsw
 // {
 //   "name": "my-package",
 //   "exports": {
@@ -55,5 +55,60 @@ test('should mock all exports from nodejsexample_01_exports', () => {
 
   assert.strictEqual(
     resolvewithplus('nodejsexample_01_exports/package.json'),
+    noderesolvedpackagejson)
+});
+
+// from: https://nodejs.org/api/packages.html#package-entry-pointsw
+// {
+//   "name": "my-package",
+//   "exports": {
+//     ".": "./lib/index.js",
+//     "./lib": "./lib/index.js",
+//     "./lib/*": "./lib/*.js",
+//     "./lib/*.js": "./lib/*.js",
+//     "./feature": "./feature/index.js",
+//     "./feature/*": "./feature/*.js",
+//     "./feature/*.js": "./feature/*.js",
+//     "./package.json": "./package.json"
+//   }
+// }
+test('should mock all exports from nodejsexample_02_exports', async () => {
+  const noderesolvedlibindex = path
+    .resolve('./nodejsexample_02_exports/lib/index.js');
+  const noderesolvedfeatureindex = path
+    .resolve('./nodejsexample_02_exports/feature/index.js');
+  const noderesolvedpackagejson = path
+    .resolve('./nodejsexample_02_exports/package.json');
+  
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/lib'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/lib/index'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/lib/index.js'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/feature'),
+    noderesolvedfeatureindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/feature/index'),
+    noderesolvedfeatureindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/feature/index.js'),
+    noderesolvedfeatureindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_02_exports/package.json'),
     noderesolvedpackagejson)
 });

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -3,7 +3,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import resolvewithplus from 'resolvewithplus';
 
-// from: https://nodejs.org/api/packages.html#package-entry-pointsw
+// from: https://nodejs.org/api/packages.html#package-entry-points
 // {
 //   "name": "my-package",
 //   "exports": {

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -72,7 +72,7 @@ test('should mock all exports from nodejsexample_01_exports', () => {
 //     "./package.json": "./package.json"
 //   }
 // }
-test('should mock all exports from nodejsexample_02_exports', async () => {
+test('should mock all exports from nodejsexample_02_exports', () => {
   const noderesolvedlibindex = path
     .resolve('./nodejsexample_02_exports/lib/index.js');
   const noderesolvedfeatureindex = path

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -112,3 +112,41 @@ test('should mock all exports from nodejsexample_02_exports', () => {
     resolvewithplus('nodejsexample_02_exports/package.json'),
     noderesolvedpackagejson)
 });
+
+// from: https://nodejs.org/api/packages.html#package-entry-points
+// {
+//   "name": "my-package",
+//   "exports": {
+//     ".": "./lib/index.js",
+//     "./feature/*.js": "./feature/*.js",
+//     "./feature/internal/*": null
+//   }
+// }
+test('should mock all exports from nodejsexample_03_exports', () => {
+  const noderesolvedlibindex = path
+    .resolve('./nodejsexample_03_exports/lib/index.js');
+  const noderesolvedfeatureindex = path
+    .resolve('./nodejsexample_03_exports/feature/index.js');
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_03_exports'),
+    noderesolvedlibindex);
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_03_exports/feature'),
+    noderesolvedfeatureindex);
+});
+
+// from: https://nodejs.org/api/packages.html#package-entry-points
+// {
+//   "name": "my-package",
+//   "exports": "./lib/index.js"
+// }
+test('should mock all exports from nodejsexample_04_exports', () => {
+  const noderesolvedlibindex = path
+    .resolve('./nodejsexample_04_exports/lib/index.js');
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_04_exports'),
+    noderesolvedlibindex);
+});

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -58,7 +58,7 @@ test('should mock all exports from nodejsexample_01_exports', () => {
     noderesolvedpackagejson)
 });
 
-// from: https://nodejs.org/api/packages.html#package-entry-pointsw
+// from: https://nodejs.org/api/packages.html#package-entry-points
 // {
 //   "name": "my-package",
 //   "exports": {


### PR DESCRIPTION
please review this small PR

This PR adds the second set of example esm export patterns from nodejs' documentation site here https://nodejs.org/api/packages.html#package-entry-points
```json
{
  "name": "my-package",
  "exports": {
    ".": "./lib/index.js",
    "./lib": "./lib/index.js",
    "./lib/*": "./lib/*.js",
    "./lib/*.js": "./lib/*.js",
    "./feature": "./feature/index.js",
    "./feature/*": "./feature/*.js",
    "./feature/*.js": "./feature/*.js",
    "./package.json": "./package.json"
  }
}
```

The tests are maybe a little easy and better tests could be added later.  Some resolutions were verified with something like this, not committed,
```javascript
const imported = await import( 'nodejsexample_02_exports/lib' );
```