### PR TITLE
feat: support core modules with `node:` prefix

### DIFF
--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -8,7 +8,7 @@ const require = module.createRequire(import.meta.url);
 // which is also used by nodejs' internal resolver
 const realpath = fs.realpathSync.native;
 const isBuiltinRe = new RegExp(
-  '^('+module.builtinModules.join('|').replace('/', '\/')+')$');
+  '^(?:node:)?('+module.builtinModules.join('|').replace('/', '\/')+')$');
 const isDirPathRe = /^\.?\.?(\/|\\)/;
 const isRelPathRe = /^.\.?(?=\/|\\)/;
 const isSupportedIndexRe = /index.[tj]sx?$/;

--- a/tests/tests-basic/tests-basic.test.js
+++ b/tests/tests-basic/tests-basic.test.js
@@ -12,6 +12,11 @@ test('should return a core module reference as require.resolve id', () => {
   assert.strictEqual(resolvewithplus('path'), 'path');
 });
 
+// eslint-disable-next-line max-len
+test('should return a core module prefixed with \'node:\' reference as require.resolve id', () => {
+  assert.strictEqual(resolvewithplus('node:path'), 'node:path');
+});
+
 test('should return a full path when given relative path to index file', () => {
   const fullpath = path.resolve('../testfiles/');
   const indexPath = path.resolve('../testfiles/path/to/indexfile/index.js')


### PR DESCRIPTION
As of versions 14.18.0 and 16.0.0, core modules can also be identified
by prepending `node:` to the module name. This change patches the
RegExp used to determine whether a module is a code module by allowing
an optional `node:` prefix.