### PR TITLE
return encoded url same as import.meta.resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.0.0 _Oct.19.2022_
+  * return encoded url [same as import.meta.resolve](https://github.com/iambumblehead/resolvewithplus/pull/40) 
  * 1.0.2 _Sep.24.2022_
    * add test and changes to [support import.meta.resolve](https://github.com/iambumblehead/resolvewithplus/pull/39)
  * 1.0.1 _Sep.15.2022_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resolvewithplus",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "engines" : { 
     "node" : ">=12.16.0"
   },

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import url from 'node:url'
+import url from 'url'
 import path from 'path'
 import module from 'module'
 

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import url from 'url'
+import url from 'node:url'
 import path from 'path'
 import module from 'module'
 
@@ -19,7 +19,6 @@ const packageNameRe = /(^@[^/]*\/[^/]*|^[^/]*)\/?(.*)$/
 const isESMImportSubpathRe = /^#/
 const esmStrGlobRe = /(\*)/g
 const esmStrPathCharRe = /([./])/g
-const rootDirSlashRe = /^\//
 const protocolNode = /^node:/
 const protocolFile = /^file:/
 const supportedExtensions = [ '.js', '.mjs', '.ts', '.tsx', '.json', '.node' ]
@@ -33,7 +32,7 @@ const isobj = o => o && typeof o === 'object'
 const cache = {}
 
 const addprotocolnode = p => protocolNode.test(p) ? p : `node:${p}`
-const addprotocolfile = p => p && ('file:///' + p.replace(rootDirSlashRe, ''))
+const addprotocolfile = p => p && url.pathToFileURL(p).href
 const iscoremodule = p => isBuiltinRe.test(p)
 const getaspath = p => protocolFile.test(p) ? url.fileURLToPath(p) : p
 const getasdirname = p =>

--- a/tests/testfiles/path/to/indexfile/file name with spaces.js
+++ b/tests/testfiles/path/to/indexfile/file name with spaces.js
@@ -1,0 +1,1 @@
+module.exports = 'hellow'

--- a/tests/tests-basic/tests-basic.test.js
+++ b/tests/tests-basic/tests-basic.test.js
@@ -61,6 +61,7 @@ test('should return fileurl paths, as import.meta.resolve', async () => {
   const fullpath = path.resolve('../testfiles') + '/'
   const fullpathfileurl = tofileurl(fullpath)
   const relpathtoindex = '../testfiles/path/to/indexfile/index.js'
+  const relpathtonamewithspaces = '../testfiles/path/to/indexfile/file name with spaces.js'
   const metaresolve = import.meta.resolve
 
   assert.strictEqual(
@@ -98,6 +99,10 @@ test('should return fileurl paths, as import.meta.resolve', async () => {
   assert.strictEqual(
     await metaresolve(relpathtoindex, import.meta.url),
     resolvewithplus(relpathtoindex, import.meta.url))
+
+  assert.strictEqual(
+    await metaresolve(relpathtonamewithspaces, import.meta.url),
+    resolvewithplus(relpathtonamewithspaces, import.meta.url))
 })
 
 test('should return a full path when given relative path to index file', () => {

--- a/tests/tests-basic/tests-basic.test.js
+++ b/tests/tests-basic/tests-basic.test.js
@@ -61,7 +61,7 @@ test('should return fileurl paths, as import.meta.resolve', async () => {
   const fullpath = path.resolve('../testfiles') + '/'
   const fullpathfileurl = tofileurl(fullpath)
   const relpathtoindex = '../testfiles/path/to/indexfile/index.js'
-  const relpathtonamewithspaces = '../testfiles/path/to/indexfile/file name with spaces.js'
+  const relpathspace = '../testfiles/path/to/indexfile/file name with spaces.js'
   const metaresolve = import.meta.resolve
 
   assert.strictEqual(
@@ -101,8 +101,8 @@ test('should return fileurl paths, as import.meta.resolve', async () => {
     resolvewithplus(relpathtoindex, import.meta.url))
 
   assert.strictEqual(
-    await metaresolve(relpathtonamewithspaces, import.meta.url),
-    resolvewithplus(relpathtonamewithspaces, import.meta.url))
+    await metaresolve(relpathspace, import.meta.url),
+    resolvewithplus(relpathspace, import.meta.url))
 })
 
 test('should return a full path when given relative path to index file', () => {


### PR DESCRIPTION
updated resolvewithplus to
  * return this, 'file:///path/to/indexfile/file%20name%20with%20spaces.js'
  * rather than this, 'file:///path/to/indexfile/file name with spaces.js'