### PR TITLE
fix node_modules lookup

### DIFF
--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -36,7 +36,7 @@ const addprotocolfile = p => p && url.pathToFileURL(p).href
 const iscoremodule = p => isBuiltinRe.test(p)
 const getaspath = p => protocolFile.test(p) ? url.fileURLToPath(p) : p
 const getasdirname = p =>
-  path.resolve(path.extname(p) ? path.dirname(p) : p) + '/'
+  path.resolve(path.extname(p) ? path.dirname(p) : p) + path.sep;
 
 // ex, D:\\a\\resolvewithplus\\pathto\\testfiles\\testscript.js
 //  -> D:/a/resolvewithplus/pathto/testfiles/testscript.js
@@ -66,7 +66,7 @@ const isfilesync = (file, stat) => {
 //    b. DIRS = DIRS + DIR
 //    c. let I = I - 1
 // 5. return DIRS
-const getasnode_module_paths = start => start.split(path.sep).slice(1)
+const getasnode_module_paths = start => start.split(path.sep)
   .reduce((prev, p, i) => {
     // the second condition allow resolvewithplus unit-tests to pass,
     // when resolvewithplus is inside another package's node_modules
@@ -75,10 +75,10 @@ const getasnode_module_paths = start => start.split(path.sep).slice(1)
 
     // windows and linux paths split differently
     // [ "D:", "a", "windows", "path" ] vs [ "", "linux", "path" ]
-    p = path.resolve(path.join(i ? prev[0][i-1] : path.sep, p))
-    
+    p = i ? path.join(prev[0][i-1], p) : p || path.sep
+
     prev[0].push(p)
-    prev[1].push(path.join(p, node_modules))
+    prev[1].push(path.resolve(path.join(p, node_modules)))
 
     return prev
   }, [ [], [] ])[1].reverse()

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -36,7 +36,7 @@ const addprotocolfile = p => p && url.pathToFileURL(p).href
 const iscoremodule = p => isBuiltinRe.test(p)
 const getaspath = p => protocolFile.test(p) ? url.fileURLToPath(p) : p
 const getasdirname = p =>
-  path.resolve(path.extname(p) ? path.dirname(p) : p) + path.sep;
+  path.resolve(path.extname(p) ? path.dirname(p) : p) + path.sep
 
 // ex, D:\\a\\resolvewithplus\\pathto\\testfiles\\testscript.js
 //  -> D:/a/resolvewithplus/pathto/testfiles/testscript.js

--- a/tests/tests-basic/tests-basic.test.js
+++ b/tests/tests-basic/tests-basic.test.js
@@ -231,41 +231,16 @@ test('getasdirsync, should return path with index, if found', () => {
     resolvewithplus.getasdirsync(fullpath), fullpathindexjs)
 })
 
-test('getasnode_module_paths, should return list of paths (posix)', () => {
-  const fullpath = path.resolve('../testfiles/path/to/indexfile')
-  const { sep } = path
-  const paths = fullpath.split(sep).slice(1).reduce((prev, p, i) => {
-    if (p === 'node_modules' && !/[\\/]resolvewithplus[\\/]/.test(fullpath))
-      return prev
+test('getasnode_module_paths, should return paths to node_modules', () => {
+  const { relative, resolve } = path
+  const fullpath = resolve('../testfiles/path/to/indexfile')
+  const pathsToLook = resolvewithplus.getasnode_module_paths(fullpath)
+  const relativePaths = pathsToLook.map(pathToLook =>
+    relative(fullpath, pathToLook))
 
-    p = path.resolve(path.join(i ? prev[0][i-1] : sep, p))
-    
-    prev[0].push(p)
-    prev[1].push(path.join(p, 'node_modules'))
-
-    return prev
-  }, [ [], [] ])[1].reverse()
-
-  // [
-  //   '/home/bumble/resolvewithplus/testfiles/path/to/indexfile/node_modules',
-  //   '/home/bumble/resolvewithplus/testfiles/path/to/node_modules',
-  //   '/home/bumble/resolvewithplus/testfiles/path/node_modules',
-  //   '/home/bumble/resolvewithplus/testfiles/node_modules',
-  //   '/home/bumble/resolvewithplus/node_modules',
-  //   '/home/bumble/node_modules',
-  //   '/home/node_modules'
-  // ]
-  //
-  // [
-  //   'D:\\a\\resolvewithplus\\testfiles\\path\\to\\indexfile\\node_modules',
-  //   'D:\\a\\resolvewithplus\\testfiles\\path\\to\\node_modules',
-  //   'D:\\a\\resolvewithplus\\testfiles\\path\\node_modules',
-  //   'D:\\a\\resolvewithplus\\testfiles\\node_modules',
-  //   'D:\\a\\resolvewithplus\\node_modules',
-  //   'D:\\a\\node_modules'
-  // ]
-  assert.deepEqual(
-    resolvewithplus.getasnode_module_paths(fullpath), paths)
+  for (const relativePath of relativePaths) {
+    assert.match(relativePath, /^(\.\.[/\\])*node_modules/)
+  }
 })
 
 test('should handle exports.import path definition', () => {


### PR DESCRIPTION
`getasnode_module_paths` is dropping the drive letter (d:) and recreating with default c:.

`getasnode_module_paths` test is using the same logic as getasnode_module_paths, the test is broken.

This PR adjusts the paths resolution and tests.