### PR TITLE
improve isTypescript resolution of moduleIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # changelog
 
- * 2.0.3 _Sep.09.2023_
+ * 2.0.4 _Sep.12.2023_
+  * [improve resolution](https://github.com/iambumblehead/resolvewithplus/pull/48) of typescript moduleIds
+ * 2.0.3 _Sep.12.2023_
   * pin node 20.4 at unit-test pipeline, last version of node before import.meta.resolve was reduced
   * [add workspaces unit-tests](https://github.com/iambumblehead/resolvewithplus/pull/46)
   * [add detection of ".ts"](https://github.com/iambumblehead/resolvewithplus/pull/47) parent extension for applying typescript conditions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resolvewithplus",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "resolvewith with extra power",
   "readmeFilename": "README.md",
   "license": "ISC",

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -262,10 +262,14 @@ const gettargetindex = (packagejson, opts) => {
 // 2. If X.js is a file, load X.js as JavaScript text.  STOP
 // 3. If X.json is a file, parse X.json to a JavaScript Object.  STOP
 // 4. If X.node is a file, load X.node as binary addon.  STOP
-const getasfilesync = f => {
+const getasfilesync = (f, opts = {}) => {
   var filepath = null
+  var filepathts = opts.isTypescript
+      && isJsExtnRe.test(f) && f.replace(isJsExtnRe, '.ts')
 
-  if (isfilesync(f)) {
+  if (isfilesync(filepathts)) {
+    filepath = filepathts
+  } else if (isfilesync(f)) {
     filepath = f
   } else {
     supportedExtensions
@@ -293,14 +297,8 @@ const getasdirsync = (d, opts) => {
   if ((relpath = gettargetindex(jsonobj, opts))) {
     filepath = getasfilesync(path.join(d, relpath))
   } else if ((relpath = jsonobj.main)) {
-    if (opts.isTypescript && isJsExtnRe.test(relpath)) {
-      filepath = getasfilesync(path.join(d, relpath.replace(isJsExtnRe, '.ts')))
-        || getasfilesync(path.join(d, relpath))
-        || getasfilesync(path.join(d, path.join(relpath, 'index')))
-    } else {
-      filepath = getasfilesync(path.join(d, relpath))
-        || getasfilesync(path.join(d, path.join(relpath, 'index')))
-    }
+    filepath = getasfilesync(path.join(d, relpath), opts)
+      || getasfilesync(path.join(d, path.join(relpath, 'index')))
   } else {
     supportedExtensions.some(f => (
       (f = path.join(d, `index${f}`)) && isfilesync(f) && (filepath = f)))

--- a/tests/tests-basic/workspaces-ts/ts-b/test.ts
+++ b/tests/tests-basic/workspaces-ts/ts-b/test.ts
@@ -2,11 +2,16 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import resolvewithplus from '../../../../resolvewithplus.js'
 
-console.log('test here!')
-/*
 test('should return workspace paths', () => {
-  assert.strictEqual(
-    import.meta.resolve('ts-a'),
-    resolvewithplus('ts-a'))
+  const resolved = resolvewithplus('ts-a', import.meta.url)
+  const expected = import.meta.url.replace('ts-b/test.ts', 'ts-a/index.ts')
+
+  assert.strictEqual(resolved, expected)
 })
-*/
+
+test('should return ts path from js', () => {
+  const resolved = resolvewithplus('./index.js', import.meta.url)
+  const expected = import.meta.url.replace('ts-b/test.ts', 'ts-b/index.ts')
+
+  assert.strictEqual(resolved, expected)
+})


### PR DESCRIPTION
this PR changes the location of isTypescript detection to occur in one place that is more widely used so that it can be engaged more frequently to improve typescript resolution.

also, a test that was accidentally commented-out is un-commented-out