### PR TITLE
replace reduce with recursive function call

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,8 @@
     }],
     "camelcase": [2, {"properties": "never", "allow": [
       "node_module",
-      "first_parent"
+      "first_parent",
+      "next_module"
     ] }],
     "no-underscore-dangle": 0,
     "func-names": [2, "never"],
@@ -73,7 +74,7 @@
     "no-use-before-define": [2, "nofunc"],
     "no-nested-ternary": 0,
     "array-bracket-spacing": [2, "always"],
-    "prefer-destructuring": 2,
+    "prefer-destructuring": 0,
     "class-methods-use-this": 0,
     "no-confusing-arrow": 0
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * 2.0.6 _Oct.10.2023_
   * [update README image link](https://github.com/iambumblehead/resolvewithplus/pull/52) to use "main" repo path
+  * [replace reducer function](https://github.com/iambumblehead/resolvewithplus/pull/53) w/ simple recursion
  * 2.0.5 _Sep.13.2023_
   * [improve performance](https://github.com/iambumblehead/resolvewithplus/pull/49) slightly
   * [use main branch](https://github.com/iambumblehead/resolvewithplus/pull/50) rather than master

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -95,7 +95,7 @@ const getasnode_module_paths = (start, parts = start.split(path.sep)) => {
 
     // windows and linux paths split differently
     // [ "D:", "a", "windows", "path" ] vs [ "", "linux", "path" ]
-    const part = parts[0].length
+    const part = tuple[0].length
       ? path.join(tuple[0].slice(-1)[0], parts[0])
       : parts[0] || path.sep
 


### PR DESCRIPTION
The removed-reducer has some problematic behaviour around the reducer index value. Replacing the reducer with a recursive function removes the index value. Also, the reducer was composed in a way difficult to debug and the new function is a little easier to debug and interdict.