### PR TITLE
resolve named-properties that are also asterisk folder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+ * 2.1.4 _Jan.01.2024_
+   * [resolve nested exports defined on named-properties](https://github.com/iambumblehead/resolvewithplus/pull/65) with wildcards, eg `exports: { './*': { default: './src/*/index.js' } }` resolves [this issue at esmock](https://github.com/iambumblehead/esmock/issues/289)
  * 2.1.3 _Oct.20.2023_
    * resolve full path from package.json "main", "browser" and "module" definitions. resolves [this issue at esmock.](https://github.com/iambumblehead/esmock/issues/260)
  * 2.1.2 _Oct.19.2023_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resolvewithplus",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "resolvewith with extra power",
   "readmeFilename": "README.md",
   "license": "ISC",

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -205,25 +205,25 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
       // ```
       if (isobj(esmval) && esmkey.includes('*')) {
         const resolvedkey = idpath // 'mystuff'
-        const expandedkey = path.join(idpath, esmkey) // 'mystuff/*'
+        const expandedkey = path.posix.join(idpath, esmkey) // 'mystuff/*'
         const expandedspec = Object.keys(esmval).reduce((exp, nestkey) => {
           // ./src/*/index.js -> 'src'
           const pathfirstdir = esmval[nestkey].split(/\.?\//).find(e => e)
 
           // eg,
           // exp[nestkey] = getesmkeyvalglobreplaced(
-          //   './mystuff/*.js',
-          //   './src/mystuff/*.js',
-          //   './mystuff/index.js')
+          //   'mystuff/*',
+          //   'src/mystuff/*',
+          //   'mystuff/index')
           console.log([
             expandedkey,
-            path.join(pathfirstdir, expandedkey),
-            path.join(resolvedkey, esmval[nestkey].split('*')[1])
+            path.posix.join(pathfirstdir, expandedkey),
+            path.posix.join(resolvedkey, esmval[nestkey].split('*')[1])
           ])
           exp[nestkey] = getesmkeyvalglobreplaced(
             expandedkey,
-            path.join(pathfirstdir, expandedkey),
-            path.join(resolvedkey, esmval[nestkey].split('*')[1]))
+            path.posix.join(pathfirstdir, expandedkey),
+            path.posix.join(resolvedkey, esmval[nestkey].split('*')[1]))
 
           return exp
         }, {})

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -204,10 +204,8 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
       // }
       // ```
       if (isobj(esmval) && esmkey.includes('*')) {
-        console.log([ esmkey, idpath, idpath ])        
-        const resolvedkey = getesmkeyvalglobreplaced(esmkey, idpath, idpath)
-        // './mystuff', './*' -> 'mystuff/*',
-        const expandedkey = path.join(resolvedkey, esmkey)
+        const resolvedkey = idpath // 'mystuff'
+        const expandedkey = path.join(idpath, esmkey) // 'mystuff/*'
         const expandedspec = Object.keys(esmval).reduce((exp, nestkey) => {
           // ./src/*/index.js -> 'src'
           const pathfirstdir = esmval[nestkey].split(/\.?\//).find(e => e)
@@ -217,11 +215,6 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
           //   './mystuff/*.js',
           //   './src/mystuff/*.js',
           //   './mystuff/index.js')
-          console.log([
-            expandedkey,
-            path.join(pathfirstdir, expandedkey),
-            path.join(resolvedkey, esmval[nestkey].split('*')[1])            
-          ])
           exp[nestkey] = getesmkeyvalglobreplaced(
             expandedkey,
             path.join(pathfirstdir, expandedkey),

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -207,19 +207,13 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
         const resolvedkey = idpath // 'mystuff'
         const expandedkey = path.posix.join(idpath, esmkey) // 'mystuff/*'
         const expandedspec = Object.keys(esmval).reduce((exp, nestkey) => {
-          // ./src/*/index.js -> 'src'
-          const pathfirstdir = esmval[nestkey].split(/\.?\//).find(e => e)
+          const pathfirstdir = esmval[nestkey] // ./src/a/b.js -> 'src'
+            .split(/\.?\//).find(e => e)
 
           // eg,
-          // exp[nestkey] = getesmkeyvalglobreplaced(
-          //   'mystuff/*',
-          //   'src/mystuff/*',
-          //   'mystuff/index')
-          console.log([
-            expandedkey,
-            path.posix.join(pathfirstdir, expandedkey),
-            path.posix.join(resolvedkey, esmval[nestkey].split('*')[1])
-          ])
+          // getesmkeyvalglobreplaced(
+          //   'mystuff/*', 'src/mystuff/*', 'mystuff/index.js')
+          // 'src/mystuff/index.js'
           exp[nestkey] = getesmkeyvalglobreplaced(
             expandedkey,
             path.posix.join(pathfirstdir, expandedkey),

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -216,6 +216,11 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
           //   './mystuff/*.js',
           //   './src/mystuff/*.js',
           //   './mystuff/index.js')
+          console.log([
+            expandedkey,
+            path.join(pathfirstdir, expandedkey),
+            path.join(resolvedkey, esmval[nestkey].split('*')[1])            
+          ])
           exp[nestkey] = getesmkeyvalglobreplaced(
             expandedkey,
             path.join(pathfirstdir, expandedkey),

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -215,6 +215,11 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
           //   './mystuff/*.js',
           //   './src/mystuff/*.js',
           //   './mystuff/index.js')
+          console.log([
+            expandedkey,
+            path.join(pathfirstdir, expandedkey),
+            path.join(resolvedkey, esmval[nestkey].split('*')[1])
+          ])
           exp[nestkey] = getesmkeyvalglobreplaced(
             expandedkey,
             path.join(pathfirstdir, expandedkey),

--- a/resolvewithplus.js
+++ b/resolvewithplus.js
@@ -204,6 +204,7 @@ const getesmkeyvalmatch = (esmkey, esmval, idpath, opts, keyvalmx = false) => {
       // }
       // ```
       if (isobj(esmval) && esmkey.includes('*')) {
+        console.log([ esmkey, idpath, idpath ])        
         const resolvedkey = getesmkeyvalglobreplaced(esmkey, idpath, idpath)
         // './mystuff', './*' -> 'mystuff/*',
         const expandedkey = path.join(resolvedkey, esmkey)

--- a/tests/tests-basic/nodejsexample_13_exports/package.json
+++ b/tests/tests-basic/nodejsexample_13_exports/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nodejsexample_13_exports",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iambumblehead/resolvewithplus.git"
+  },
+  "exports": {
+    "./*": {
+      "default": "./src/*/index.js",
+      "types": "./types/*/index.d.ts"
+    }
+  }
+}

--- a/tests/tests-basic/nodejsexample_13_exports/src/mystuff/index.js
+++ b/tests/tests-basic/nodejsexample_13_exports/src/mystuff/index.js
@@ -1,0 +1,1 @@
+export default 'mystuff'

--- a/tests/tests-basic/nodejsexample_13_exports/types/mystuff/index.d.ts
+++ b/tests/tests-basic/nodejsexample_13_exports/types/mystuff/index.d.ts
@@ -1,0 +1,5 @@
+declare const mystuff: string
+
+export {
+  mystuff as default
+}

--- a/tests/tests-basic/package.json
+++ b/tests/tests-basic/package.json
@@ -18,6 +18,7 @@
     "nodejsexample_10_exports": "file:nodejsexample_10_exports",
     "nodejsexample_11_exports": "file:nodejsexample_11_exports",
     "nodejsexample_12_exports": "file:nodejsexample_12_exports",
+    "nodejsexample_13_exports": "file:nodejsexample_13_exports",
     "resolvewithplus": "file:.."
   },
   "workspaces": [

--- a/tests/tests-basic/tests-export-patterns.test.js
+++ b/tests/tests-basic/tests-export-patterns.test.js
@@ -275,6 +275,25 @@ test('should mock exports from nodejsexample_12_exports, nested cond', () => {
     noderesolvedfeaturenode)
 })
 
+// "asterisk-directory named-property exports"
+// from: https://github.com/iambumblehead/esmock/issues/289 @dschnare
+// {
+//   "exports": {
+//     "./*": {
+//       "default": "./src/*/index.js",
+//       "types": "./types/*/index.d.ts"
+//     }
+//   }
+// }
+test('should mock exports from nodejsexample_13_exports, asterisk dir', () => {
+  const noderesolvedindex = toresolvefileurl(
+    './nodejsexample_13_exports/src/mystuff/index.js')
+
+  assert.strictEqual(
+    resolvewithplus('nodejsexample_13_exports/mystuff'),
+    noderesolvedindex)
+})
+
 // "exports": './lib/index.js',
 // "exports": { "import": "./lib/index.js" },
 // "exports": { ".": "./lib/index.js" },


### PR DESCRIPTION
cc @koshic (also @dschnare)

This PR is for resolving https://github.com/iambumblehead/esmock/issues/289 eg, importing a moduleId "mymodule/mystuff" should return "mymodule/src/mystuff/index.js" given the below "mymodule" package.json,

``` json
{
  "name": "mymodule",
  "type": "module",
  "exports": {
    "./*": {
      "default": "./src/*/index.js",
      "types": "./types/*/index.d.ts"
    }
  }
}
```

While changes here may not be great, they only occur inside specific conditions that would currently fail every time. A few function calls were updated to include the "opts" param, beecause "opts" are needed by the esmparse function which is called in new place here.

First, the script checks to see if the property name includes an asterisk and if the definition is an object
```javascript
if (isobj(esmval) && esmkey.includes('*')) {
  // ...
}
```

If that condition is true it generates an "expanded" version of the spec. eg, for moduleId "stuff",
```javascript
{
  default: './src/mystuff/index.js',
  types: './types/mystuff/index.d.ts'
}
```

and tries to resolve the moduleId using the "expanded" spec value
```javascript
esmparse({
  default: './src/mystuff/index.js',
  types: './types/mystuff/index.d.ts'
}, 'mystuff', opts) // ./src/mystuff/index.js
```
